### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "lodash.isundefined": "^3.0.1",
     "lodash.sortby": "^3.1.5",
     "lodash.without": "^3.2.1",
-    "node-uuid": "^1.4.7",
     "object-hash": "^0.9.2",
-    "tern": "^0.18.0"
+    "tern": "^0.18.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^2.1.0",

--- a/src/parser.js
+++ b/src/parser.js
@@ -12,7 +12,7 @@ const without = require('lodash.without')
 const get = require('lodash.get')
 const objectHash = require('object-hash')
 const clone = require('lodash.clonedeep')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 
 
 class Parser {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.